### PR TITLE
workaround issue MVCC_READ_CONFLICT on concurrent createAnchor calls https://github.com/PharmaLedger-IMI/blockchain-hf-workspace/issues/3

### DIFF
--- a/cc-anchor/lib/chaincode/hlfPersistence.js
+++ b/cc-anchor/lib/chaincode/hlfPersistence.js
@@ -206,13 +206,16 @@ function ChainCodeOperations(){
         });
         ccPersistence.putState(anchorId, Buffer.from(jsonStr)).then(
             ()=>{
-                self.incrementTotalNumberOfAnchors(anchorId, ccPersistence,(err) =>{
-                    if (err){
-                        console.log(err);
-                        return callback(err);
-                    }
-                    return callback(undefined);
-                });
+                // workaround issue MVCC_READ_CONFLICT on concurrent createAnchor calls
+                // https://github.com/PharmaLedger-IMI/blockchain-hf-workspace/issues/3 
+                // self.incrementTotalNumberOfAnchors(anchorId, ccPersistence,(err) =>{
+                //     if (err){
+                //         console.log(err);
+                //         return callback(err);
+                //     }
+                //     return callback(undefined);
+                // });
+                return callback(undefined);
             },
             (err)=>{
                 console.log(err);


### PR DESCRIPTION
https://github.com/PharmaLedger-IMI/blockchain-hf-workspace/issues/3

Following interactive session with @bmastahac , here is the PR for the changes experimented in the discussion.
I am not sure if I understood the issue entirely, but here is the PR. Feel free to reject it.
The tests (in FGT DEV environment) so far are promising.